### PR TITLE
Add manual trigger to GitHub Actions workflow

### DIFF
--- a/.github/workflows/NumericParserWeb20240928144547.yml
+++ b/.github/workflows/NumericParserWeb20240928144547.yml
@@ -1,5 +1,6 @@
 name: Build and deploy .NET app to Azure Web App
 on:
+  workflow_dispatch:
   push:
     branches:
     - master


### PR DESCRIPTION
Introduce `workflow_dispatch` event to allow manual triggering of the GitHub Actions workflow. The existing trigger for pushes to the `master` branch remains unchanged.